### PR TITLE
cb called twice if err

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ var GoogleSheets = function(ssKey, authId, options) {
 
     ], function(err, results) {
       if (err) cb(err);
-      cb(null, results[1].result, results[1].body);
+      else cb(null, results[1].result, results[1].body);
     });
   };
 


### PR DESCRIPTION
Prevents a TypeError on line 123, because results is an empty array when there's an error.